### PR TITLE
Stream response bodies instead of always buffering them completely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.php_cs
 /behat.yml
 /build/
+/coverage
 /composer.lock
 /phpspec.yml
 /phpunit.xml

--- a/src/Internal/ResponseStream.php
+++ b/src/Internal/ResponseStream.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Http\Adapter\Artax\Internal;
+
+use Amp\Artax;
+use Amp\ByteStream\InputStream;
+use Amp\ByteStream\IteratorStream;
+use Amp\CancellationTokenSource;
+use Amp\CancelledException;
+use Amp\Emitter;
+use Amp\Promise;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * PSR-7 stream implementation that converts an `Amp\ByteStream\InputStream` into a PSR-7 compatible stream.
+ *
+ * @internal
+ */
+class ResponseStream implements StreamInterface
+{
+    private $buffer = '';
+    private $position = 0;
+    private $eof = false;
+
+    private $body;
+    private $cancellationTokenSource;
+
+    /**
+     * @param InputStream             $body                    HTTP response stream to wrap.
+     * @param CancellationTokenSource $cancellationTokenSource Cancellation source bound to the request to abort it.
+     */
+    public function __construct(InputStream $body, CancellationTokenSource $cancellationTokenSource)
+    {
+        $this->body = $body;
+        $this->cancellationTokenSource = $cancellationTokenSource;
+    }
+
+    public function __toString()
+    {
+        try {
+            return $this->getContents();
+        } catch (\Throwable $e) {
+            return '';
+        }
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    public function close()
+    {
+        $this->cancellationTokenSource->cancel();
+
+        $emitter = new Emitter();
+        $emitter->fail(new Artax\HttpException('The stream has been closed'));
+        $this->body = new IteratorStream($emitter->iterate());
+    }
+
+    public function detach()
+    {
+        $this->close();
+    }
+
+    public function getSize()
+    {
+        return null;
+    }
+
+    public function tell()
+    {
+        return $this->position;
+    }
+
+    public function eof()
+    {
+        return $this->eof;
+    }
+
+    public function isSeekable()
+    {
+        return false;
+    }
+
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        throw new \RuntimeException('Stream is not seekable');
+    }
+
+    public function rewind()
+    {
+        $this->seek(0);
+    }
+
+    public function isWritable()
+    {
+        return false;
+    }
+
+    public function write($string)
+    {
+        throw new \RuntimeException('Stream is not writable');
+    }
+
+    public function isReadable()
+    {
+        return true;
+    }
+
+    public function read($length)
+    {
+        if ($this->eof) {
+            return '';
+        }
+
+        if ($this->buffer === '') {
+            try {
+                $this->buffer = Promise\wait($this->body->read());
+            } catch (Artax\HttpException $e) {
+                throw new \RuntimeException('Reading from the stream failed', 0, $e);
+            } catch (CancelledException $e) {
+                throw new \RuntimeException('Reading from the stream failed', 0, $e);
+            }
+
+            if ($this->buffer === null) {
+                $this->eof = true;
+
+                return '';
+            }
+        }
+
+        $read = \substr($this->buffer, 0, $length);
+        $this->buffer = (string) \substr($this->buffer, $length);
+        $this->position += \strlen($read);
+
+        return $read;
+    }
+
+    public function getContents()
+    {
+        $buffer = '';
+
+        while (!$this->eof()) {
+            $buffer .= $this->read(8192 * 8);
+        }
+
+        return $buffer;
+    }
+
+    public function getMetadata($key = null)
+    {
+        return $key === null ? [] : null;
+    }
+}

--- a/tests/ResponseStreamTest.php
+++ b/tests/ResponseStreamTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Http\Adapter\Artax\Test;
+
+use Amp\ByteStream\InMemoryStream;
+use Amp\ByteStream\IteratorStream;
+use Amp\CancellationTokenSource;
+use Amp\CancelledException;
+use Amp\Emitter;
+use Http\Adapter\Artax\Internal\ResponseStream;
+use PHPUnit\Framework\TestCase;
+use function Amp\Iterator\fromIterable;
+
+class ResponseStreamTest extends TestCase
+{
+    public function testNotSeekable()
+    {
+        $stream = new ResponseStream(new InMemoryStream(), new CancellationTokenSource());
+        $this->assertFalse($stream->isSeekable());
+
+        $this->expectException(\RuntimeException::class);
+        $stream->seek(0);
+    }
+
+    public function testNotRewindable()
+    {
+        $stream = new ResponseStream(new InMemoryStream(), new CancellationTokenSource());
+
+        $this->expectException(\RuntimeException::class);
+        $stream->rewind();
+    }
+
+    public function testNotWritable()
+    {
+        $stream = new ResponseStream(new InMemoryStream(), new CancellationTokenSource());
+        $this->assertFalse($stream->isWritable());
+
+        $this->expectException(\RuntimeException::class);
+        $stream->write('');
+    }
+
+    public function testReadSlowStream()
+    {
+        $inputStream = new IteratorStream(fromIterable(['a', 'b', 'c'], 100));
+        $stream = new ResponseStream($inputStream, new CancellationTokenSource());
+        $this->assertTrue($stream->isReadable());
+
+        $this->assertSame('abc', (string) $stream);
+
+        // As the stream isn't rewindable, we get an empty result here.
+        $this->assertSame('', (string) $stream);
+
+        $this->assertSame(3, $stream->tell());
+
+        $this->assertSame('', $stream->read(8192));
+    }
+
+    public function testReadAfterClose()
+    {
+        $inputStream = new IteratorStream(fromIterable(['a', 'b', 'c'], 100));
+        $stream = new ResponseStream($inputStream, new CancellationTokenSource());
+
+        $stream->close();
+
+        $this->expectException(\RuntimeException::class);
+        $stream->read(8192);
+    }
+
+    public function testStringCastAfterClose()
+    {
+        $inputStream = new IteratorStream(fromIterable(['a', 'b', 'c'], 100));
+        $stream = new ResponseStream($inputStream, new CancellationTokenSource());
+
+        $stream->close();
+
+        $this->assertSame('', (string) $stream);
+    }
+
+    public function testReadAfterCancel()
+    {
+        $emitter = new Emitter();
+        $emitter->fail(new CancelledException());
+        $inputStream = new IteratorStream($emitter->iterate());
+        $stream = new ResponseStream($inputStream, new CancellationTokenSource());
+
+        $this->expectException(\RuntimeException::class);
+        $stream->read(8192);
+    }
+
+    public function testReadAfterDetach()
+    {
+        $inputStream = new IteratorStream(fromIterable(['a', 'b', 'c'], 100));
+        $stream = new ResponseStream($inputStream, new CancellationTokenSource());
+
+        $stream->detach();
+
+        $this->expectException(\RuntimeException::class);
+        $stream->read(8192);
+    }
+
+    public function testMetadata()
+    {
+        $stream = new ResponseStream(new InMemoryStream(), new CancellationTokenSource());
+        $this->assertNull($stream->getMetadata('foobar'));
+        $this->assertInternalType('array', $stream->getMetadata());
+    }
+
+    public function testSize()
+    {
+        $stream = new ResponseStream(new InMemoryStream(), new CancellationTokenSource());
+        $this->assertNull($stream->getSize());
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | kinda
| New feature?    | kinda
| BC breaks?      | unknown
| Deprecations?   | no
| Related tickets | Mentioned in #3.
| License         | MIT

#### What's in this PR?

Use a custom `StreamInterface` implementation to allow for proper backpressure.

#### Why?

Large responses have to be held entirely in memory otherwise.