### PR TITLE
WIP: bump dependencies, support amphp/http-client and httplug v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "amphp/http-client": "^4.5"
     },
     "require-dev": {
-        "amphp/phpunit-util": "^1",
         "php-http/message": "^1.6",
-        "phpunit/phpunit": "^9.4",
-        "php-http/client-integration-tests": "^3.0"
+        "phpunit/phpunit": "^7.5",
+        "php-http/client-integration-tests": "^3.0",
+        "amphp/phpunit-util": "^1.4"
     },
     "provide": {
         "php-http/client-implementation": "1.0"

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,15 @@
     },
     "require": {
         "php": "^7.0",
-        "amphp/artax": "^3.0",
-        "php-http/httplug": "^1.1",
-        "php-http/discovery": "^1.2"
+        "php-http/httplug": "^2.2",
+        "php-http/discovery": "^1.12",
+        "amphp/http-client": "^4.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
         "amphp/phpunit-util": "^1",
-        "php-http/client-integration-tests": "^0.6.2",
-        "php-http/message": "^1.6"
+        "php-http/message": "^1.6",
+        "phpunit/phpunit": "^9.4",
+        "php-http/client-integration-tests": "^3.0"
     },
     "provide": {
         "php-http/client-implementation": "1.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,4 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
-    <listeners>
-        <listener class="Amp\PHPUnit\LoopReset" />
-    </listeners>
 </phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,17 +2,21 @@
 
 namespace Http\Adapter\Artax;
 
-use Amp\Artax;
 use Amp\CancellationTokenSource;
+use Amp\Http\Client\HttpClient as AmpHttpClient;
+use Amp\Http\Client\HttpClientBuilder;
+use Amp\Http\Client\HttpException;
+use Amp\Http\Client\Request;
 use Amp\Promise;
 use Http\Client\Exception\RequestException;
 use Http\Client\Exception\TransferException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
-use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Message\ResponseFactory;
 use Http\Message\StreamFactory;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use function Amp\call;
 
 class Client implements HttpClient, HttpAsyncClient
@@ -22,17 +26,17 @@ class Client implements HttpClient, HttpAsyncClient
     private $responseFactory;
 
     /**
-     * @param Artax\Client    $client          HTTP client implementation.
-     * @param ResponseFactory $responseFactory Response factory to use or `null` to attempt auto-discovery.
-     * @param StreamFactory   $streamFactory   This parameter will be ignored and removed in the next major version.
+     * @param AmpHttpClient $client          HTTP client implementation.
+     * @param ResponseFactory        $responseFactory Response factory to use or `null` to attempt auto-discovery.
+     * @param StreamFactory          $streamFactory   This parameter will be ignored and removed in the next major version.
      */
     public function __construct(
-        Artax\Client $client = null,
+        AmpHttpClient $client = null,
         ResponseFactory $responseFactory = null,
         StreamFactory $streamFactory = null
     ) {
-        $this->client = $client ?? new Artax\DefaultClient();
-        $this->responseFactory = $responseFactory ?? MessageFactoryDiscovery::find();
+        $this->client = $client ?? HttpClientBuilder::buildDefault();
+        $this->responseFactory = $responseFactory ?? Psr17FactoryDiscovery::findResponseFactory();
 
         if (null === $streamFactory || 3 === \func_num_args()) {
             @\trigger_error('The $streamFactory parameter is deprecated and ignored.', \E_USER_DEPRECATED);
@@ -40,7 +44,7 @@ class Client implements HttpClient, HttpAsyncClient
     }
 
     /** {@inheritdoc} */
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request) : ResponseInterface
     {
         return $this->doRequest($request)->wait();
     }
@@ -57,18 +61,15 @@ class Client implements HttpClient, HttpAsyncClient
             call(function () use ($request, $useInternalStream) {
                 $cancellationTokenSource = new CancellationTokenSource();
 
-                /** @var Artax\Request $req */
-                $req = new Artax\Request($request->getUri(), $request->getMethod());
-                $req = $req->withProtocolVersions([$request->getProtocolVersion()]);
-                $req = $req->withHeaders($request->getHeaders());
-                $req = $req->withBody((string) $request->getBody());
+                $req = new Request($request->getUri(), $request->getMethod(), (string) $request->getBody());
+//                $req = $req->withProtocolVersions([$request->getProtocolVersion()]);
+                foreach ($request->getHeaders() as $headerName => $headerValue) {
+                    $req->addHeader($headerName, $headerValue);
+                }
 
                 try {
-                    /** @var Artax\Response $resp */
-                    $resp = yield $this->client->request($req, [
-                        Artax\Client::OP_MAX_REDIRECTS => 0,
-                    ], $cancellationTokenSource->getToken());
-                } catch (Artax\HttpException $e) {
+                    $resp = yield $this->client->request($req, $cancellationTokenSource->getToken());
+                } catch (HttpException $e) {
                     throw new RequestException($e->getMessage(), $request, $e);
                 } catch (\Throwable $e) {
                     throw new TransferException($e->getMessage(), 0, $e);
@@ -80,15 +81,13 @@ class Client implements HttpClient, HttpAsyncClient
                     $body = yield $resp->getBody();
                 }
 
-                $response = $this->responseFactory->createResponse(
+                return $this->responseFactory->createResponse(
                     $resp->getStatus(),
                     $resp->getReason(),
                     $resp->getHeaders(),
                     $body,
                     $resp->getProtocolVersion()
                 );
-
-                return $response;
             })
         );
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,24 +11,24 @@ use Amp\Promise;
 use Http\Client\Exception\RequestException;
 use Http\Client\Exception\TransferException;
 use Http\Client\HttpAsyncClient;
-use Http\Client\HttpClient;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Message\ResponseFactory;
 use Http\Message\StreamFactory;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use function Amp\call;
 
-class Client implements HttpClient, HttpAsyncClient
+class Client implements ClientInterface, HttpAsyncClient
 {
     private $client;
 
     private $responseFactory;
 
     /**
-     * @param AmpHttpClient $client          HTTP client implementation.
-     * @param ResponseFactory        $responseFactory Response factory to use or `null` to attempt auto-discovery.
-     * @param StreamFactory          $streamFactory   This parameter will be ignored and removed in the next major version.
+     * @param AmpHttpClient   $client          HTTP client implementation.
+     * @param ResponseFactory $responseFactory Response factory to use or `null` to attempt auto-discovery.
+     * @param StreamFactory   $streamFactory   This parameter will be ignored and removed in the next major version.
      */
     public function __construct(
         AmpHttpClient $client = null,
@@ -62,7 +62,6 @@ class Client implements HttpClient, HttpAsyncClient
                 $cancellationTokenSource = new CancellationTokenSource();
 
                 $req = new Request($request->getUri(), $request->getMethod(), (string) $request->getBody());
-//                $req = $req->withProtocolVersions([$request->getProtocolVersion()]);
                 foreach ($request->getHeaders() as $headerName => $headerValue) {
                     $req->addHeader($headerName, $headerValue);
                 }

--- a/src/Internal/ResponseStream.php
+++ b/src/Internal/ResponseStream.php
@@ -2,12 +2,12 @@
 
 namespace Http\Adapter\Artax\Internal;
 
-use Amp\Artax;
 use Amp\ByteStream\InputStream;
 use Amp\ByteStream\IteratorStream;
 use Amp\CancellationTokenSource;
 use Amp\CancelledException;
 use Amp\Emitter;
+use Amp\Http\Client\HttpException;
 use Amp\Promise;
 use Psr\Http\Message\StreamInterface;
 
@@ -57,7 +57,7 @@ class ResponseStream implements StreamInterface
         $this->cancellationTokenSource->cancel();
 
         $emitter = new Emitter();
-        $emitter->fail(new Artax\HttpException('The stream has been closed'));
+        $emitter->fail(new HttpException('The stream has been closed'));
         $this->body = new IteratorStream($emitter->iterate());
     }
 
@@ -120,7 +120,7 @@ class ResponseStream implements StreamInterface
         if ('' === $this->buffer) {
             try {
                 $this->buffer = Promise\wait($this->body->read());
-            } catch (Artax\HttpException $e) {
+            } catch (HttpException $e) {
                 throw new \RuntimeException('Reading from the stream failed', 0, $e);
             } catch (CancelledException $e) {
                 throw new \RuntimeException('Reading from the stream failed', 0, $e);

--- a/tests/AsyncClientTest.php
+++ b/tests/AsyncClientTest.php
@@ -4,7 +4,7 @@ declare(ticks=1);
 
 namespace Http\Adapter\Artax\Test;
 
-use Amp\Artax;
+use Amp\Http\Client\HttpClientBuilder;
 use Amp\Loop;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -15,10 +15,9 @@ use Http\Client\Tests\HttpAsyncClientTest;
 class AsyncClientTest extends HttpAsyncClientTest
 {
     /** @return HttpAsyncClient */
-    protected function createHttpAsyncClient()
+    protected function createHttpAsyncClient() : HttpAsyncClient
     {
-        $client = new Artax\DefaultClient();
-        $client->setOption(Artax\Client::OP_TRANSFER_TIMEOUT, 1000);
+        $client = HttpClientBuilder::buildDefault();
 
         return new Client($client);
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,18 +2,18 @@
 
 namespace Http\Adapter\Artax\Test;
 
-use Amp\Artax;
+use Amp\Http\Client\HttpClientBuilder;
 use Http\Adapter\Artax\Client;
 use Http\Client\HttpClient;
 use Http\Client\Tests\HttpClientTest;
+use Psr\Http\Client\ClientInterface;
 
 class ClientTest extends HttpClientTest
 {
     /** @return HttpClient */
-    protected function createHttpAdapter()
+    protected function createHttpAdapter() : ClientInterface
     {
-        $client = new Artax\DefaultClient();
-        $client->setOption(Artax\Client::OP_TRANSFER_TIMEOUT, 1000);
+        $client = HttpClientBuilder::buildDefault();
 
         return new Client($client);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Documentation   | will update if we can proceed with this
| License         | MIT


#### What's in this PR?

Add support for php-http/httplug v2 to work with amphp/http-client instead of deprecated v3 version amphp/artax

Possibly this could result in a completely new repository/adapter implementation..


#### Why?

...


#### Example Usage

``` php

use Amp\Http\Client\HttpClient;
use Amp\Http\Client\HttpClientBuilder;
use Http\Adapter\Artax\Client as AmpHttpAdapter;
use Http\Message\MessageFactory\GuzzleMessageFactory;

$adapter = new ArtaxAdapter(HttpClientBuilder::buildDefault(), new GuzzleMessageFactory());

```


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] refactor namespace to e.g. Http\Adapter\AmpHttpClient\Client etc.
- [ ] ...discuss
- [ ] build/ci
